### PR TITLE
spring-boot-configuration-processor for @ConfigurationProperties

### DIFF
--- a/spring-boot-zalando-stups-tokens/pom.xml
+++ b/spring-boot-zalando-stups-tokens/pom.xml
@@ -32,6 +32,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!--process @ConfigurationProperties-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- TEST -->
         <dependency>


### PR DESCRIPTION
generate META-INF/spring-configuration-metadata.json to enable IDE autocomplete
